### PR TITLE
Improve combinedargs and valid_didargs

### DIFF
--- a/.github/workflows/CI-latest.yml
+++ b/.github/workflows/CI-latest.yml
@@ -41,5 +41,5 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - name: Install latest dependencies
-        run: julia --project=. -e 'using Pkg; Pkg.add(name="DiffinDiffsBase", rev="master"); Pkg.instantiate()'
+        run: julia --project=. -e 'using Pkg; Pkg.add(PackageSpec(name="DiffinDiffsBase", rev="master")); Pkg.instantiate()'
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/CI-latest.yml
+++ b/.github/workflows/CI-latest.yml
@@ -41,5 +41,5 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - name: Install latest dependencies
-        run: julia --project=. -e "using Pkg; Pkg.add(PackageSpec(name=\"DiffinDiffsBase\", rev=\"master\")); Pkg.instantiate()"
+        run: julia --project=. -e "using Pkg; Pkg.add(PackageSpec(name=\""DiffinDiffsBase\"", rev=\""master\"")); Pkg.instantiate()"
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/CI-latest.yml
+++ b/.github/workflows/CI-latest.yml
@@ -41,5 +41,5 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - name: Install latest dependencies
-        run: julia --project=. -e 'using Pkg; Pkg.add(PackageSpec(name="DiffinDiffsBase", rev="master")); Pkg.instantiate()'
+        run: julia --project=. -e "using Pkg; Pkg.add(PackageSpec(name=\"DiffinDiffsBase\", rev=\"master\")); Pkg.instantiate()"
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/CI-stable.yml
+++ b/.github/workflows/CI-stable.yml
@@ -43,7 +43,7 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - name: Install latest dependencies
-        run: julia --project=. -e "using Pkg; Pkg.add(PackageSpec(name=\"DiffinDiffsBase\", rev=\"master\")); Pkg.instantiate()"
+        run: julia --project=. -e "using Pkg; Pkg.add(PackageSpec(name=\""DiffinDiffsBase\"", rev=\""master\"")); Pkg.instantiate()"
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/CI-stable.yml
+++ b/.github/workflows/CI-stable.yml
@@ -43,7 +43,7 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - name: Install latest dependencies
-        run: julia --project=. -e 'using Pkg; Pkg.add(PackageSpec(name="DiffinDiffsBase", rev="master")); Pkg.instantiate()'
+        run: julia --project=. -e 'using Pkg; pkg"add DiffinDiffsBase#master"; Pkg.instantiate()'
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/CI-stable.yml
+++ b/.github/workflows/CI-stable.yml
@@ -43,7 +43,7 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - name: Install latest dependencies
-        run: julia --project=. -e 'using Pkg; Pkg.add(name="DiffinDiffsBase", rev="master"); Pkg.instantiate()'
+        run: julia --project=. -e 'using Pkg; Pkg.add(PackageSpec(name="DiffinDiffsBase", rev="master")); Pkg.instantiate()'
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/CI-stable.yml
+++ b/.github/workflows/CI-stable.yml
@@ -43,7 +43,7 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - name: Install latest dependencies
-        run: julia --project=. -e 'using Pkg; pkg"add DiffinDiffsBase#master"; Pkg.instantiate()'
+        run: julia --project=. -e "using Pkg; Pkg.add(PackageSpec(name=\"DiffinDiffsBase\", rev=\"master\")); Pkg.instantiate()"
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1

--- a/src/InteractionWeightedDIDs.jl
+++ b/src/InteractionWeightedDIDs.jl
@@ -20,7 +20,7 @@ using DiffinDiffsBase: termvars, hasintercept, omitsintercept, isintercept, pars
 
 import Base: show
 import DiffinDiffsBase: required, default, transformed, combinedargs, copyargs,
-    _get_default, valid_didargs, result
+    valid_didargs, result, _count!
 import FixedEffectModels: has_fe
 
 export Vcov,

--- a/src/did.jl
+++ b/src/did.jl
@@ -9,17 +9,24 @@ const RegressionBasedDID = DiffinDiffsEstimator{:RegressionBasedDID,
 
 const Reg = RegressionBasedDID
 
-function _get_default(::Reg, @nospecialize(ntargs::NamedTuple))
-    defaults = (subset=nothing, weightname=nothing, vce=Vcov.RobustCovariance(),
-        treatintterms=(), xterms=(), drop_singletons=true, nfethreads=Threads.nthreads(),
-        contrasts=nothing, fetol=1e-8, femaxiter=10000, cohortinteracted=true)
-    return merge(defaults, ntargs)
-end
-
 function valid_didargs(d::Type{Reg}, ::DynamicTreatment{SharpDesign},
-        ::TrendParallel{Unconditional, Exact}, @nospecialize(ntargs::NamedTuple))
-    ntargs = _get_default(d(), ntargs)
-    name = haskey(ntargs, :name) ? ntargs.name : ""
+        ::TrendParallel{Unconditional, Exact}, args::Dict{Symbol,Any})
+    name = get(args, :name, "")::String
+    ntargs = (data=args[:data], tr=args[:tr]::DynamicTreatment{SharpDesign},
+        pr=args[:pr]::TrendParallel{Unconditional, Exact},
+        yterm=args[:yterm]::Union{Term,FunctionTerm},
+        treatname=args[:treatname]::Symbol,
+        subset=get(args, :subset, nothing)::Union{BitVector,Nothing},
+        weightname=get(args, :weightname, nothing)::Union{Symbol,Nothing},
+        vce=get(args, :vce, Vcov.RobustCovariance())::Vcov.CovarianceEstimator,
+        treatintterms=get(args, :treatintterms, ())::Terms,
+        xterms=get(args, :xterms, ())::Terms,
+        drop_singletons=get(args, :drop_singletons, true)::Bool,
+        nfethreads=get(args, :nfethreads, Threads.nthreads())::Int,
+        contrasts=get(args, :contrasts, nothing)::Union{Dict{Symbol,Any},Nothing},
+        fetol=get(args, :fetol, 1e-8)::Float64,
+        femaxiter=get(args, :femaxiter, 10000)::Int,
+        cohortinteracted=get(args, :cohortinteracted, true)::Bool)
     return name, d, ntargs
 end
 

--- a/test/did.jl
+++ b/test/did.jl
@@ -1,8 +1,6 @@
 @testset "RegressionBasedDID" begin
     hrs = exampledata("hrs")
 
-    @test _get_default(Reg(), NamedTuple()) == merge((default(s) for s in Reg())...)
-
     r = @did(Reg, data=hrs, dynamic(:wave, -1), notyettreated([11]),
         vce=Vcov.cluster(:hhidpn), yterm=term(:oop_spend), treatname=:wave_hosp,
         treatintterms=(), xterms=(fe(:wave)+fe(:hhidpn)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,8 +3,7 @@ using InteractionWeightedDIDs
 
 using DataFrames
 using Dictionaries
-using DiffinDiffsBase: required, default, transformed, combinedargs, valid_didargs,
-    _get_default, @fieldequal
+using DiffinDiffsBase: required, default, transformed, combinedargs, valid_didargs, @fieldequal
 using FixedEffectModels: Combination, nunique
 using FixedEffects
 using InteractionWeightedDIDs: checkvcov!, checkfes!, makefesolver,


### PR DESCRIPTION
The original implementation of `combinedargs` triggers recompilation whenever the number of `StatsSpec`s changes. Such recompilation has been avoided now.

`valid_didargs` now accepts a `Dict` and generates a `NamedTuple` with specified fields in a fixed order.