### PR TITLE
Add ParseFEterms, GroupFEterms and MakeFEs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Vcov = "ec2bfdc2-55df-4fc9-b9ae-4958c2cf2486"
 [compat]
 DataAPI = "1.5"
 DataFrames = "1"
-DiffinDiffsBase = "0.3.2"
+DiffinDiffsBase = "0.3.3"
 FixedEffectModels = "1.5"
 FixedEffects = "2"
 Reexport = "0.2, 1"

--- a/src/InteractionWeightedDIDs.jl
+++ b/src/InteractionWeightedDIDs.jl
@@ -3,7 +3,7 @@ module InteractionWeightedDIDs
 using Base: Callable
 using DataAPI: refarray
 using FixedEffectModels: FixedEffectTerm, Combination,
-    fe, _parse_fixedeffect, invsym!, isnested, nunique
+    fe, fesymbol, _multiply, invsym!, isnested, nunique
 using FixedEffects
 using LinearAlgebra: Cholesky, Factorization, Symmetric, cholesky!, diag
 using Reexport
@@ -26,6 +26,9 @@ export Vcov,
        fe
 
 export CheckVcov,
+       ParseFEterms,
+       GroupFEterms,
+       MakeFEs,
        CheckFEs,
        MakeFESolver,
        MakeYXCols,

--- a/src/did.jl
+++ b/src/did.jl
@@ -4,7 +4,8 @@
 Estimation procedure for regression-based difference-in-differences.
 """
 const RegressionBasedDID = DiffinDiffsEstimator{:RegressionBasedDID,
-    Tuple{CheckData, GroupTerms, CheckVcov, CheckVars, CheckFEs, MakeWeights, MakeFESolver,
+    Tuple{CheckData, GroupTreatintterms, GroupXterms, CheckVcov, CheckVars, GroupSample,
+    ParseFEterms, GroupFEterms, MakeFEs, CheckFEs, MakeWeights, MakeFESolver,
     MakeYXCols, MakeTreatCols, SolveLeastSquares, EstVcov, SolveLeastSquaresWeights}}
 
 const Reg = RegressionBasedDID
@@ -64,7 +65,7 @@ struct RegressionBasedDIDResult{TR<:AbstractTreatment, CohortInteracted} <: DIDR
     xterms::Vector{AbstractTerm}
     contrasts::Union{Dict{Symbol, Any}, Nothing}
     weightname::Union{Symbol, Nothing}
-    fenames::Vector{Symbol}
+    fenames::Vector{String}
     nfeiterations::Union{Int, Nothing}
     feconverged::Union{Bool, Nothing}
     nfesingledropped::Int

--- a/src/procedures.jl
+++ b/src/procedures.jl
@@ -75,7 +75,7 @@ groupfeterms(feterms::Set{FETerm}) = (feterms=feterms,)
 """
     GroupFEterms <: StatsStep
 
-Call [`DiffinDiffsBase.groupfeterms`](@ref)
+Call [`InteractionWeightedDIDs.groupfeterms`](@ref)
 to obtain one of the instances of `feterms`
 that have been grouped by equality (`hash`)
 for allowing later comparisons based on object-id.

--- a/src/procedures.jl
+++ b/src/procedures.jl
@@ -26,73 +26,173 @@ exclude rows that are invalid for variance-covariance estimator.
 """
 const CheckVcov = StatsStep{:CheckVcov, typeof(checkvcov!), true}
 
+# Get esample and aux directly from CheckData
 required(::CheckVcov) = (:data, :esample, :aux)
 default(::CheckVcov) = (vce=Vcov.robust(),)
 copyargs(::CheckVcov) = (2,)
 
 """
+    parsefeterms!(xterms)
+
+Extract any `FixedEffectTerm` or interaction of `FixedEffectTerm` from `xterms`
+and determine whether any intercept term should be omitted.
+See also [`ParseFEterms`](@ref).
+"""
+function parsefeterms!(xterms::TermSet)
+    feterms = Set{FETerm}()
+    has_fe_intercept = false
+    for t in xterms
+        result = _parsefeterm(t)
+        if result !== nothing
+            push!(feterms, result)
+            delete!(xterms, t)
+        end
+    end
+    if !isempty(feterms)
+        if any(t->isempty(t[2]), feterms)
+            has_fe_intercept = true
+            for t in xterms
+                t isa Union{ConstantTerm,InterceptTerm} && delete!(xterms, t)
+            end
+            push!(xterms, InterceptTerm{false}())
+        end
+    end
+    return (xterms=xterms, feterms=feterms, has_fe_intercept=has_fe_intercept)
+end
+
+const ParseFEterms = StatsStep{:ParseFEterms, typeof(parsefeterms!), true}
+
+required(::ParseFEterms) = (:xterms,)
+
+"""
+    groupfeterms(feterms)
+
+Return the argument without change for allowing later comparisons based on object-id.
+See also [`GroupFEterms`](@ref).
+"""
+groupfeterms(feterms::Set{FETerm}) = (feterms=feterms,)
+
+"""
+    GroupFEterms <: StatsStep
+
+Call [`DiffinDiffsBase.groupfeterms`](@ref)
+to obtain one of the instances of `feterms`
+that have been grouped by equality (`hash`)
+for allowing later comparisons based on object-id.
+
+This step is only useful when working with [`@specset`](@ref) and [`proceed`](@ref).
+"""
+const GroupFEterms = StatsStep{:GroupFEterms, typeof(groupfeterms), false}
+
+required(::GroupFEterms) = (:feterms,)
+
+"""
+    makefes(args...)
+
+Construct `FixedEffect`s from `data` (the full sample).
+See also [`MakeFEs`](@ref).
+"""
+function makefes(data, allfeterms::Vector{FETerm})
+    # Must use Dict instead of IdDict since the same feterm can be in multiple feterms
+    allfes = Dict{FETerm,FixedEffect}()
+    for t in allfeterms
+        haskey(allfes, t) && continue
+        if isempty(t[2])
+            allfes[t] = FixedEffect((getcolumn(data, n) for n in t[1])...)
+        else
+            allfes[t] = FixedEffect((getcolumn(data, n) for n in t[1])...;
+                interaction=_multiply(data, t[2]))
+        end
+    end
+    return (allfes=allfes,)
+end
+
+"""
+    MakeFEs <: StatsStep
+
+Call [`InteractionWeightedDIDs.makefes`](@ref)
+to construct `FixedEffect`s from `data` (the full sample).
+"""
+const MakeFEs = StatsStep{:MakeFEs, typeof(makefes), false}
+
+required(::MakeFEs) = (:data,)
+combinedargs(::MakeFEs, allntargs) = (FETerm[t for nt in allntargs for t in nt.feterms],)
+
+"""
     checkfes!(args...)
 
-Extract any `FixedEffectTerm` from `xterms`,
-drop singleton observations for any fixed effect
-and determine whether intercept term should be omitted.
+Drop any singleton observation from fixed effects over the relevant subsample.
 See also [`CheckFEs`](@ref).
 """
-function checkfes!(data, esample::BitVector, xterms::TermSet, drop_singletons::Bool)
-    fes, fenames, has_fe_intercept = parse_fixedeffect!(data, xterms)
+function checkfes!(feterms::Set{FETerm}, allfes::Dict{FETerm,FixedEffect},
+        esample::BitVector, drop_singletons::Bool)
     nsingle = 0
-    if !isempty(fes)
+    nfe = length(feterms)
+    if nfe > 0
+        fes = Vector{FixedEffect}(undef, nfe)
+        fenames = Vector{String}(undef, nfe)
+        # Loop together to ensure the orders are the same
+        for (i, t) in enumerate(feterms)
+            fes[i] = allfes[t]
+            fenames[i] = getfename(t)
+        end
+        # Determine the unique order based on names
+        order = sortperm(fenames)
+        fes = fes[order]
+        fenames = fenames[order]
+
         if drop_singletons
             for fe in fes
                 nsingle += drop_singletons!(esample, fe)
             end
         end
+        sum(esample) == 0 && error("no nonmissing data")
+
+        for i in 1:nfe
+            fes[i] = fes[i][esample]
+        end
+        return (esample=esample, fes=fes, fenames=fenames, nsingle=nsingle)
+    else
+        return (esample=esample, fes=FixedEffect[], fenames=String[], nsingle=0)
     end
-    sum(esample) == 0 && error("no nonmissing data")
-    return (xterms=xterms, esample=esample, fes=fes, fenames=fenames,
-        has_fe_intercept=has_fe_intercept, nsingle=nsingle)
 end
 
 """
     CheckFEs <: StatsStep
 
 Call [`InteractionWeightedDIDs.checkfes!`](@ref)
-to extract any `FixedEffectTerm` from `xterms`
-and drop singleton observations for any fixed effect.
+to drop any singleton observation from fixed effects over the relevant subsample.
 """
-const CheckFEs = StatsStep{:CheckFixedEffects, typeof(checkfes!), true}
+const CheckFEs = StatsStep{:CheckFEs, typeof(checkfes!), true}
 
-required(::CheckFEs) = (:data, :esample, :xterms)
+required(::CheckFEs) = (:feterms, :allfes, :esample)
 default(::CheckFEs) = (drop_singletons=true,)
-copyargs(::CheckFEs) = (2,3)
+copyargs(::CheckFEs) = (3,)
 
 """
-    makefesolver!(args...)
+    makefesolver(args...)
 
 Construct `FixedEffects.AbstractFixedEffectSolver`.
 See also [`MakeFESolver`](@ref).
 """
-function makefesolver!(fes::Vector{FixedEffect}, weights::AbstractWeights,
-        esample::BitVector, nfethreads::Int)
+function makefesolver(fes::Vector{FixedEffect}, weights::AbstractWeights, nfethreads::Int)
     if !isempty(fes)
-        fes = FixedEffect[fe[esample] for fe in fes]
         feM = AbstractFixedEffectSolver{Float64}(fes, weights, Val{:cpu}, nfethreads)
-        return (feM=feM, fes=fes)
+        return (feM=feM,)
     else
-        return (feM=nothing, fes=fes)
+        return (feM=nothing,)
     end
 end
 
 """
     MakeFESolver <: StatsStep
 
-Call [`InteractionWeightedDIDs.makefesolver!`](@ref) to construct the fixed effect solver.
+Call [`InteractionWeightedDIDs.makefesolver`](@ref) to construct the fixed effect solver.
 """
-const MakeFESolver = StatsStep{:MakeFESolver, typeof(makefesolver!), true}
+const MakeFESolver = StatsStep{:MakeFESolver, typeof(makefesolver), true}
 
-required(::MakeFESolver) = (:fes, :weights, :esample)
+required(::MakeFESolver) = (:fes, :weights)
 default(::MakeFESolver) = (nfethreads=Threads.nthreads(),)
-copyargs(::MakeFESolver) = (1,)
 
 function _makeyxcols!(yxterms::Dict, yxcols::Dict, yxschema, data, t::AbstractTerm)
     ct = apply_schema(t, yxschema, StatisticalModel)
@@ -291,6 +391,7 @@ transformed(::MakeTreatCols, @nospecialize(nt::NamedTuple)) = (nt.tr.time,)
 # Obtain the relative time periods excluded by all tr
 # and the treatment groups excluded by all pr in allntargs
 function combinedargs(::MakeTreatCols, allntargs)
+    # exc cannot be IdDict for comparing different types of one
     exc = Dict{Int,Int}()
     notreat = IdDict{ValidTimeType,Int}()
     for nt in allntargs

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,4 @@
+# A vector of fixed effects paired with a vector of interactions (empty if not interacted)
 const FETerm = Pair{Vector{Symbol},Vector{Symbol}}
 
 # Parse fixed effects from a generic term

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,29 +1,25 @@
-function parse_fixedeffect!(data, ts::TermSet)
-    fes = FixedEffect[]
-    ids = Symbol[]
-    has_fe_intercept = false
-    for term in ts
-        result = _parse_fixedeffect(data, term)
-        if result !== nothing
-            push!(fes, result[1])
-            push!(ids, result[2])
-            delete!(ts, term)
-        end
+const FETerm = Pair{Vector{Symbol},Vector{Symbol}}
+
+# Parse fixed effects from a generic term
+function _parsefeterm(@nospecialize(t::AbstractTerm))
+    if has_fe(t)
+        s = fesymbol(t)
+        return [s]=>Symbol[]
     end
-    order = sortperm(ids)
-    fes .= fes[order]
-    ids .= ids[order]
-    if !isempty(fes)
-        if any(fe->fe.interaction isa UnitWeights, fes)
-            has_fe_intercept = true
-            for t in ts
-                t isa Union{ConstantTerm,InterceptTerm} && delete!(ts, t)
-            end
-            push!(ts, InterceptTerm{false}())
-        end
-    end
-    return fes, ids, has_fe_intercept
 end
+
+# Parse fixed effects from an InteractionTerm
+function _parsefeterm(@nospecialize(t::InteractionTerm))
+    fes = (x for x in t.terms if has_fe(x))
+    interactions = (x for x in t.terms if !has_fe(x))
+    if !isempty(fes)
+        fes = sort!([fesymbol(x) for x in fes])
+        feints = sort!([Symbol(x) for x in interactions])
+        return fes=>feints
+    end
+end
+
+getfename(feterm::FETerm) = join(vcat("fe_".*string.(feterm[1]), feterm[2]), "&")
 
 # Count the number of singletons dropped
 function drop_singletons!(esample, fe::FixedEffect)

--- a/test/did.jl
+++ b/test/did.jl
@@ -209,19 +209,25 @@ end
 @testset "@specset" begin
     hrs = exampledata("hrs")
     # The first two specs are identical hence no repetition of steps should occur
-    # The third spec should only share the first three steps with the others
-    r = @specset [verbose] begin
-        @did(Reg, dynamic(:wave, -1), notyettreated(11), data=hrs,
-            yterm=term(:oop_spend), treatname=:wave_hosp, treatintterms=(),
+    # The third spec should share all the steps until SolveLeastSquares
+    # The fourth and fifth specs should not add tasks for MakeFEs and MakeYXCols
+    # The sixth spec should not add any task for MakeFEs
+    r = @specset [verbose] data=hrs yterm=term(:oop_spend) treatname=:wave_hosp begin
+        @did(Reg, dynamic(:wave, -1), notyettreated(11),
             xterms=(fe(:wave)+fe(:hhidpn)))
-        @did(Reg, dynamic(:wave, -1), notyettreated(11), data=hrs,
-            yterm=term(:oop_spend), treatname=:wave_hosp, treatintterms=[],
+        @did(Reg, dynamic(:wave, -1), notyettreated(11),
             xterms=[fe(:hhidpn), fe(:wave)])
-        @did(Reg, dynamic(:wave, -1), nevertreated(11), data=hrs,
-            yterm=term(:oop_spend), treatname=:wave_hosp, treatintterms=(),
+        @did(Reg, dynamic(:wave, -2:-1), notyettreated(11),
+            xterms=[fe(:hhidpn), fe(:wave)])
+        @did(Reg, dynamic(:wave, -1), notyettreated(11),
+            xterms=[term(:male), fe(:hhidpn), fe(:wave)])
+        @did(Reg, dynamic(:wave, -1), notyettreated(11),
+            treatintterms=TermSet(:male), xterms=[fe(:hhidpn), fe(:wave)])
+        @did(Reg, dynamic(:wave, -1), nevertreated(11),
             xterms=(fe(:wave)+fe(:hhidpn)))
     end
-    @test r[1] == didspec(Reg, dynamic(:wave, -1), notyettreated(11), data=hrs,
+    # Results might differ due to yxterms that include terms from other specs
+    @test r[4] == didspec(Reg, dynamic(:wave, -1), notyettreated(11), data=hrs,
         yterm=term(:oop_spend), treatname=:wave_hosp, treatintterms=(),
-        xterms=TermSet(fe(:wave), fe(:hhidpn)))()
+        xterms=TermSet(term(:male), fe(:wave), fe(:hhidpn)))()
 end

--- a/test/procedures.jl
+++ b/test/procedures.jl
@@ -62,7 +62,8 @@ end
 
     allntargs = NamedTuple[(feterms=Set{FETerm}(),), (feterms=Set(feterms),),
         (feterms=Set(([:hhidpn]=>Symbol[],)),)]
-    @test combinedargs(MakeFEs(), allntargs) == (push!(feterms, [:hhidpn]=>Symbol[]),)
+    @test Set(combinedargs(MakeFEs(), allntargs)) ==
+        Set((push!(feterms, [:hhidpn]=>Symbol[]),))
 
     nt = (data=hrs, feterms=feterms)
     @test MakeFEs()(nt) == merge(nt, ret)

--- a/test/procedures.jl
+++ b/test/procedures.jl
@@ -14,36 +14,103 @@
         (data=hrs, esample=trues(size(hrs,1)), aux=trues(size(hrs,1)))
 end
 
+@testset "ParseFEterms" begin
+    hrs = exampledata(:hrs)
+
+    ret = parsefeterms!(TermSet())
+    @test (ret...,) == (TermSet(), Set{FETerm}(), false)
+    ts = TermSet((term(1), term(:male)))
+    ret = parsefeterms!(ts)
+    @test (ret...,) == (ts, Set{FETerm}(), false)
+
+    ts = TermSet(term(1)+term(:male)+fe(:hhidpn))
+    ret = parsefeterms!(ts)
+    @test (ret...,) == (TermSet(InterceptTerm{false}(), term(:male)),
+        Set(([:hhidpn]=>Symbol[],)), true)
+
+    ts = TermSet(fe(:wave)+fe(:hhidpn))
+    ret = parsefeterms!(ts)
+    @test (ret...,) == (TermSet(InterceptTerm{false}()),
+        Set(([:hhidpn]=>Symbol[], [:wave]=>Symbol[])), true)
+
+    # Verify that no change is made on intercept
+    ts = TermSet((term(:male), fe(:hhidpn)&term(:wave)))
+    ret = parsefeterms!(ts)
+    @test (ret...,) == (TermSet(term(:male)), Set(([:hhidpn]=>[:wave],)), false)
+
+    ts = TermSet((term(:male), fe(:hhidpn)&term(:wave)))
+    nt = (xterms=ts,)
+    @test ParseFEterms()(nt) == (xterms=TermSet(term(:male)),
+        feterms=Set(([:hhidpn]=>[:wave],)), has_fe_intercept=false)
+end
+
+@testset "GroupFEterms" begin
+    nt = (feterms=Set(([:hhidpn]=>[:wave],)),)
+    @test groupfeterms(nt...) === nt
+    _byid(GroupFEterms()) == false
+    @test GroupFEterms()(nt) === nt
+end
+
+@testset "MakeFEs" begin
+    hrs = exampledata("hrs")
+    @test makefes(hrs, FETerm[]) == (allfes=Dict{FETerm,FixedEffect}(),)
+
+    feterms = [[:hhidpn]=>Symbol[], [:hhidpn,:wave]=>[:male]]
+    ret = makefes(hrs, feterms)
+    @test ret == (allfes=Dict{FETerm,FixedEffect}(feterms[1]=>FixedEffect(hrs.hhidpn),
+        feterms[2]=>FixedEffect(hrs.hhidpn, hrs.wave, interaction=_multiply(hrs, [:male]))),)
+
+    allntargs = NamedTuple[(feterms=Set{FETerm}(),), (feterms=Set(feterms),),
+        (feterms=Set(([:hhidpn]=>Symbol[],)),)]
+    @test combinedargs(MakeFEs(), allntargs) == (push!(feterms, [:hhidpn]=>Symbol[]),)
+
+    nt = (data=hrs, feterms=feterms)
+    @test MakeFEs()(nt) == merge(nt, ret)
+end
+
 @testset "CheckFEs" begin
     hrs = exampledata("hrs")
-    nt = (data=hrs, esample=trues(size(hrs,1)), xterms=TermSet(term(:white)), drop_singletons=true)
-    @test checkfes!(nt...) == (xterms=TermSet(term(:white)),
-        esample=trues(size(hrs,1)), fes=FixedEffect[], fenames=Symbol[],
-        has_fe_intercept=false, nsingle=0)
-    nt = merge(nt, (xterms=TermSet(fe(:hhidpn)),))
-    @test checkfes!(nt...) == (xterms=TermSet(InterceptTerm{false}()),
-        esample=trues(size(hrs,1)), fes=[FixedEffect(hrs.hhidpn)], fenames=[:fe_hhidpn],
-        has_fe_intercept=true, nsingle=0)
+    N = size(hrs, 1)
+    nt = (feterms=Set{FETerm}(), allfes=Dict{FETerm,FixedEffect}(),
+        esample=trues(N), drop_singletons=true)
+    @test checkfes!(nt...) == (esample=nt.esample, fes=FixedEffect[],
+        fenames=String[], nsingle=0)
+
+    feterm = [:hhidpn]=>Symbol[]
+    allfes = makefes(hrs, [[:hhidpn]=>Symbol[], [:wave]=>[:male]]).allfes
+    nt = merge(nt, (feterms=Set((feterm,)), allfes=allfes))
+    @test checkfes!(nt...) == (esample=trues(N), fes=[FixedEffect(hrs.hhidpn)],
+        fenames=["fe_hhidpn"], nsingle=0)
     
+    # fes are sorted by name
+    feterms = Set(([:wave]=>Symbol[], [:hhidpn]=>Symbol[]))
+    allfes = makefes(hrs, [[:hhidpn]=>Symbol[], [:wave]=>Symbol[]]).allfes
+    nt = merge(nt, (feterms=feterms, allfes=allfes))
+    @test checkfes!(nt...) == (esample=trues(N),
+        fes=[FixedEffect(hrs.hhidpn), FixedEffect(hrs.wave)],
+        fenames=["fe_hhidpn", "fe_wave"], nsingle=0)
+
     df = DataFrame(hrs)
     df = df[(df.wave.==7).|((df.wave.==8).&(df.wave_hosp.==8)), :]
     N = size(df, 1)
-    nt = merge(nt, (data=df, esample=trues(N), xterms=TermSet(fe(:hhidpn))))
+    feterm = [:hhidpn]=>Symbol[]
+    allfes = makefes(df, [[:hhidpn]=>Symbol[]]).allfes
+    nt = merge(nt, (feterms=Set((feterm,)), allfes=allfes, esample=trues(N)))
     kept = df.wave_hosp.==8
-    @test checkfes!(nt...) == (xterms=TermSet(InterceptTerm{false}()), esample=kept,
-        fes=[FixedEffect(df.hhidpn)], fenames=[:fe_hhidpn], has_fe_intercept=true,
-        nsingle=N-sum(kept))
+    @test checkfes!(nt...) == (esample=kept, fes=[FixedEffect(df.hhidpn)[kept]],
+        fenames=["fe_hhidpn"], nsingle=N-sum(kept))
 
     df = df[df.wave.==7, :]
     N = size(df, 1)
-    nt = merge(nt, (data=df, esample=trues(N), xterms=TermSet(fe(:hhidpn))))
+    allfes = makefes(df, [[:hhidpn]=>Symbol[]]).allfes
+    nt = merge(nt, (allfes=allfes, esample=trues(N)))
     @test_throws ErrorException checkfes!(nt...)
 
+    nt = merge(nt, (esample=trues(N),))
     @test_throws ErrorException CheckFEs()(nt)
-    nt = merge(nt, (drop_singletons=false, esample=trues(N),
-        xterms=TermSet(fe(:hhidpn))))
-    @test CheckFEs()(nt) == merge(nt, (xterms=TermSet(InterceptTerm{false}()),
-        fes=[FixedEffect(df.hhidpn)], fenames=[:fe_hhidpn], has_fe_intercept=true, nsingle=0))
+    nt = merge(nt, (esample=trues(N), drop_singletons=false))
+    @test CheckFEs()(nt) == merge(nt, (fes=[FixedEffect(df.hhidpn)],
+        fenames=["fe_hhidpn"], nsingle=0))
 end
 
 @testset "MakeFESolver" begin
@@ -51,11 +118,11 @@ end
     N = size(hrs, 1)
     fes = FixedEffect[FixedEffect(hrs.hhidpn)]
     fenames = [:fe_hhidpn]
-    nt = (fes=fes, weights=uweights(N), esample=trues(N), default(MakeFESolver())...)
-    ret = makefesolver!(nt...)
+    nt = (fes=fes, weights=uweights(N), default(MakeFESolver())...)
+    ret = makefesolver(nt...)
     @test ret.feM isa FixedEffects.FixedEffectSolverCPU{Float64}
     nt = merge(nt, (fes=FixedEffect[],))
-    @test makefesolver!(nt...) == (feM=nothing, fes=FixedEffect[])
+    @test makefesolver(nt...) == (feM=nothing,)
     @test MakeFESolver()(nt) == merge(nt, (feM=nothing,))
 end
 

--- a/test/procedures.jl
+++ b/test/procedures.jl
@@ -62,8 +62,8 @@ end
 
     allntargs = NamedTuple[(feterms=Set{FETerm}(),), (feterms=Set(feterms),),
         (feterms=Set(([:hhidpn]=>Symbol[],)),)]
-    @test Set(combinedargs(MakeFEs(), allntargs)) ==
-        Set((push!(feterms, [:hhidpn]=>Symbol[]),))
+    @test Set(combinedargs(MakeFEs(), allntargs)...) ==
+        Set(push!(feterms, [:hhidpn]=>Symbol[]))
 
     nt = (data=hrs, feterms=feterms)
     @test MakeFEs()(nt) == merge(nt, ret)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,10 +4,11 @@ using InteractionWeightedDIDs
 using DataFrames
 using Dates: Date, Year
 using DiffinDiffsBase: ValidTimeType, @fieldequal,
-    required, default, transformed, combinedargs, valid_didargs
-using FixedEffectModels: Combination, nunique
+    required, default, transformed, combinedargs, _byid, valid_didargs
+using FixedEffectModels: Combination, nunique, _multiply
 using FixedEffects
-using InteractionWeightedDIDs: parse_fixedeffect!, checkvcov!, checkfes!, makefesolver!,
+using InteractionWeightedDIDs: FETerm, _parsefeterm, getfename,
+    checkvcov!, parsefeterms!, groupfeterms, makefes, checkfes!, makefesolver,
     _feresiduals!, makeyxcols, maketreatcols, solveleastsquares!, estvcov,
     solveleastsquaresweights
 using LinearAlgebra

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,23 +1,10 @@
-@testset "parse_fixedeffect!" begin
-    hrs = exampledata(:hrs)
+@testset "_parsefeterm" begin
+    @test _parsefeterm(term(:male)) === nothing
+    @test _parsefeterm(fe(:hhidpn)) == ([:hhidpn]=>Symbol[])
+    @test _parsefeterm(fe(:hhidpn)&fe(:wave)&term(:male)) == ([:hhidpn, :wave]=>[:male])
+end
 
-    @test parse_fixedeffect!(hrs, TermSet()) == (FixedEffect[], Symbol[], false)
-    ts = TermSet((term(1),term(:male)))
-    @test parse_fixedeffect!(hrs, ts) == (FixedEffect[], Symbol[], false)
-
-    ts = TermSet(term(1)+term(:male)+fe(:hhidpn))
-    @test parse_fixedeffect!(hrs, ts) == ([FixedEffect(hrs.hhidpn)], [:fe_hhidpn], true)
-    @test ts == TermSet((InterceptTerm{false}(), term(:male)))
-
-    # Verify that fes are sorted by name
-    ts = TermSet(fe(:wave)+fe(:hhidpn))
-    @test parse_fixedeffect!(hrs, ts) == ([FixedEffect(hrs.hhidpn), FixedEffect(hrs.wave)],
-        [:fe_hhidpn, :fe_wave], true)
-    @test ts == TermSet(InterceptTerm{false}())
-
-    # Verify that no change is made on intercept
-    ts = TermSet((term(:male), fe(:hhidpn)&term(:wave)))
-    ret = parse_fixedeffect!(hrs, ts)
-    @test ret[2] == [Symbol("fe_hhidpn&wave")]
-    @test ts == TermSet(term(:male))
+@testset "getfename" begin
+    @test getfename([:hhidpn]=>Symbol[]) == "fe_hhidpn"
+    @test getfename([:hhidpn, :wave]=>[:male]) == "fe_hhidpn&fe_wave&male"
 end


### PR DESCRIPTION
The new `StatsStep`s allow avoiding repetitions of certain operations. In particular, `FixedEffect`s are constructed after parsing all `FixedEffectTerm`s rather than during the process. This avoids multiple instances of identical `FixedEffect`s, which can lead to unnecessary repetitions of solving fixed effects.