### PR TITLE
Fix an issue with sample weights and add more docstrings

### DIFF
--- a/src/did.jl
+++ b/src/did.jl
@@ -3,7 +3,7 @@
 
 Estimation procedure for regression-based difference-in-differences.
 
-A `StatsSpec` for this procedure accept the following arguments:
+A `StatsSpec` for this procedure accepts the following arguments:
 
 | Key | Type restriction | Default value | Description |
 |:---|:---|:---|:---|

--- a/src/did.jl
+++ b/src/did.jl
@@ -2,6 +2,29 @@
     RegressionBasedDID <: DiffinDiffsEstimator
 
 Estimation procedure for regression-based difference-in-differences.
+
+A `StatsSpec` for this procedure accept the following arguments:
+
+| Key | Type restriction | Default value | Description |
+|:---|:---|:---|:---|
+| `data` | | | A `Tables.jl`-compatible data table |
+| `tr` | `DynamicTreatment{SharpDesign}` | | Treatment specification |
+| `pr` | `TrendOrUnspecifiedPR{Unconditional,Exact}` | | Parallel trend assumption |
+| `yterm` | `AbstractTerm` | | A term for outcome variable |
+| `treatname` | `Symbol` | | Column name for the variable representing treatment time |
+| `subset` | `Union{BitVector,Nothing}` | `nothing` | Rows from `data` to be used for estimation |
+| `weightname` | `Union{Symbol,Nothing}` | `nothing` | Column name of the sample weight variable |
+| `vce` | `Vcov.CovarianceEstimator` | `Vcov.CovarianceEstimator` | Variance-covariance estimator |
+| `treatintterms` | `TermSet` | `TermSet()` | Terms interacted with the treatment indicators |
+| `xterms` | `TermSet` | `TermSet()` | Terms for covariates and fixed effects |
+| `contrasts` | `Union{Dict{Symbol,Any},Nothing}` | `nothing` | Contrast coding to be processed by `StatsModels.jl` |
+| `drop_singletons` | `Bool` | `true` | Drop singleton observations for fixed effects |
+| `nfethreads` | `Int` | `Threads.nthreads()` | Number of threads to be used for solving fixed effects |
+| `fetol` | `Float64` | `1e-8` | Tolerance level for the fixed effect solver |
+| `femaxiter` | `Int` | `10000` | Maximum number of iterations allowed for the fixed effect solver |
+| `cohortinteracted` | `Bool` | `true` | Interact treatment indicators by treatment time |
+| `solvelsweights` | `Bool` | `false` | Solve the cell-level least-square weights with default cell partition |
+| `lswtnames` | Iterable of `Symbol`s | `tuple()` | Column names from `treatcells` defining the cell partition used for solving least-square weights |
 """
 const RegressionBasedDID = DiffinDiffsEstimator{:RegressionBasedDID,
     Tuple{CheckData, GroupTreatintterms, GroupXterms, GroupContrasts,
@@ -9,6 +32,11 @@ const RegressionBasedDID = DiffinDiffsEstimator{:RegressionBasedDID,
     ParseFEterms, GroupFEterms, MakeFEs, CheckFEs, MakeWeights, MakeFESolver,
     MakeYXCols, MakeTreatCols, SolveLeastSquares, EstVcov, SolveLeastSquaresWeights}}
 
+"""
+    Reg <: DiffinDiffsEstimator
+
+Alias for [`RegressionBasedDID`](@ref).
+"""
 const Reg = RegressionBasedDID
 
 function valid_didargs(d::Type{Reg}, ::DynamicTreatment{SharpDesign},
@@ -42,6 +70,38 @@ end
     RegressionBasedDIDResult{TR,CohortInteracted,Haslsweights} <: DIDResult{TR}
 
 Estimation results from regression-based difference-in-differences.
+
+# Fields
+- `coef::Vector{Float64}`: coefficient estimates.
+- `vcov::Matrix{Float64}`: variance-covariance matrix for the estimates.
+- `vce::CovarianceEstimator`: variance-covariance estiamtor.
+- `tr::TR`: treatment specification.
+- `pr::AbstractParallel`: parallel trend assumption.
+- `treatweights::Vector{Float64}`: total sample weights from observations for which the corresponding treatment indicator takes one.
+- `treatcounts::Vector{Int}`: total number of observations for which the corresponding treatment indicator takes one.
+- `esample::BitVector`: indicator for the rows from `data` involved in estimation.
+- `nobs::Int`: number of observations involved in estimation.
+- `dof_residual::Int`: residual degree of freedom.
+- `F::Float64`: F-statistic for overall significance of regression model.
+- `p::Float64`: p-value corresponding to the F-statistic.
+- `yname::String`: name of the outcome variable.
+- `coefnames::Vector{String}`: coefficient names.
+- `coefinds::Dict{String, Int}`: a map from `coefnames` to integer indices for retrieving estimates by name.
+- `treatcells::VecColumnTable`: a tabular description of cells where a treatment indicator takes one.
+- `treatname::Symbol`: column name for the variable representing treatment time.
+- `yxterms::Dict{AbstractTerm, AbstractTerm}`: a map from all specified terms to concrete terms.
+- `yterm::AbstractTerm`: the specified term for outcome variable.
+- `xterms::Vector{AbstractTerm}`: the specified terms for covariates and fixed effects.
+- `contrasts::Union{Dict{Symbol, Any}, Nothing}`: contrast coding to be processed by `StatsModels.jl`.
+- `weightname::Union{Symbol, Nothing}`: column name of the sample weight variable.
+- `fenames::Vector{String}`: names of the fixed effects.
+- `nfeiterations::Union{Int, Nothing}`: number of iterations for the fixed effect solver to reach convergence.
+- `feconverged::Union{Bool, Nothing}`: whether the fixed effect solver has converged.
+- `nfesingledropped::Int`: number of singleton observations for fixed effects that have been dropped.
+- `lsweights::Union{TableIndexedMatrix, Nothing}`: cell-level least-square weights.
+- `cellymeans::Union{Vector{Float64}, Nothing}`: cell-level averages of the outcome variable.
+- `cellweights::Union{Vector{Float64}, Nothing}`: total sample weights for each cell.
+- `cellcounts::Union{Vector{Int}, Nothing}`: number of observations for each cell.
 """
 struct RegressionBasedDIDResult{TR,CohortInteracted,Haslsweights} <: DIDResult{TR}
     coef::Vector{Float64}
@@ -49,8 +109,8 @@ struct RegressionBasedDIDResult{TR,CohortInteracted,Haslsweights} <: DIDResult{T
     vce::CovarianceEstimator
     tr::TR
     pr::AbstractParallel
-    cellweights::Vector{Float64}
-    cellcounts::Vector{Int}
+    treatweights::Vector{Float64}
+    treatcounts::Vector{Int}
     esample::BitVector
     nobs::Int
     dof_residual::Int
@@ -71,9 +131,9 @@ struct RegressionBasedDIDResult{TR,CohortInteracted,Haslsweights} <: DIDResult{T
     feconverged::Union{Bool, Nothing}
     nfesingledropped::Int
     lsweights::Union{TableIndexedMatrix{Float64, Matrix{Float64}, VecColumnTable, VecColumnTable}, Nothing}
-    ycellmeans::Union{Vector{Float64}, Nothing}
-    ycellweights::Union{Vector{Float64}, Nothing}
-    ycellcounts::Union{Vector{Int}, Nothing}
+    cellymeans::Union{Vector{Float64}, Nothing}
+    cellweights::Union{Vector{Float64}, Nothing}
+    cellcounts::Union{Vector{Int}, Nothing}
 end
 
 function result(::Type{Reg}, @nospecialize(nt::NamedTuple))
@@ -84,12 +144,12 @@ function result(::Type{Reg}, @nospecialize(nt::NamedTuple))
     coefinds = Dict(cnames .=> 1:length(cnames))
     didresult = RegressionBasedDIDResult{typeof(nt.tr),
         nt.cohortinteracted, nt.lsweights!==nothing}(
-        nt.coef, nt.vcov_mat, nt.vce, nt.tr, nt.pr, nt.cellweights, nt.cellcounts,
+        nt.coef, nt.vcov_mat, nt.vce, nt.tr, nt.pr, nt.treatweights, nt.treatcounts,
         nt.esample, sum(nt.esample), nt.dof_resid, nt.F, nt.p,
         yname, cnames, coefinds, nt.treatcells, nt.treatname, nt.yxterms,
         yterm, nt.xterms, nt.contrasts, nt.weightname,
         nt.fenames, nt.nfeiterations, nt.feconverged, nt.nsingle,
-        nt.lsweights, nt.ycellmeans, nt.ycellweights, nt.ycellcounts)
+        nt.lsweights, nt.cellymeans, nt.cellweights, nt.cellcounts)
     return merge(nt, (result=didresult,))
 end
 
@@ -170,6 +230,22 @@ end
 
 Estimation results aggregated from a [`RegressionBasedDIDResult`](@ref).
 See also [`agg`](@ref).
+
+# Fields
+- `parent::P`: the [`RegressionBasedDIDResult`](@ref) from which the results are generated.
+- `inds::I`: indices of the coefficient estimates from `parent` used to generate the results.
+- `coef::Vector{Float64}`: coefficient estimates.
+- `vcov::Matrix{Float64}`: variance-covariance matrix for the estimates.
+- `coefweights::Matrix{Float64}`: coefficient weights used to aggregate the coefficient estimates from `parent`.
+- `treatweights::Vector{Float64}`: sum of `treatweights` from `parent` over combined `treatcells`.
+- `treatcounts::Vector{Int}`: sum of `treatcounts` from `parent` over combined `treatcells`.
+- `coefnames::Vector{String}`: coefficient names.
+- `coefinds::Dict{String, Int}`: a map from `coefnames` to integer indices for retrieving estimates by name.
+- `treatcells::VecColumnTable`: cells combined from the `treatcells` from `parent`.
+- `lsweights::Union{TableIndexedMatrix, Nothing}`: cell-level least-square weights.
+- `cellymeans::Union{Vector{Float64}, Nothing}`: cell-level averages of the outcome variable.
+- `cellweights::Union{Vector{Float64}, Nothing}`: total sample weights for each cell.
+- `cellcounts::Union{Vector{Int}, Nothing}`: number of observations for each cell.
 """
 struct AggregatedRegDIDResult{TR,Haslsweights,P<:RegressionBasedDIDResult,I} <: AggregatedDIDResult{TR,P}
     parent::P
@@ -177,17 +253,28 @@ struct AggregatedRegDIDResult{TR,Haslsweights,P<:RegressionBasedDIDResult,I} <: 
     coef::Vector{Float64}
     vcov::Matrix{Float64}
     coefweights::Matrix{Float64}
-    cellweights::Vector{Float64}
-    cellcounts::Vector{Int}
+    treatweights::Vector{Float64}
+    treatcounts::Vector{Int}
     coefnames::Vector{String}
     coefinds::Dict{String, Int}
     treatcells::VecColumnTable
     lsweights::Union{TableIndexedMatrix{Float64, Matrix{Float64}, VecColumnTable, VecColumnTable}, Nothing}
-    ycellmeans::Union{Vector{Float64}, Nothing}
-    ycellweights::Union{Vector{Float64}, Nothing}
-    ycellcounts::Union{Vector{Int}, Nothing}
+    cellymeans::Union{Vector{Float64}, Nothing}
+    cellweights::Union{Vector{Float64}, Nothing}
+    cellcounts::Union{Vector{Int}, Nothing}
 end
 
+"""
+    agg(r::RegressionBasedDIDResult{<:DynamicTreatment}, names=nothing; kwargs...)
+
+Aggregate coefficient estimates from `r` by values taken by
+the columns from `r.treatcells` indexed by `names`
+with weights proportional to `treatweights` within each relative time.
+
+# Keywords
+- `bys=nothing`: columnwise transformations over `r.treatcells` before grouping by `names`.
+- `subset=nothing`: subset of treatment coefficients used for aggregation.
+"""
 function agg(r::RegressionBasedDIDResult{<:DynamicTreatment}, names=nothing;
         bys=nothing, subset=nothing)
     inds = subset === nothing ? Colon() : _parse_subset(r, subset, false)
@@ -200,19 +287,19 @@ function agg(r::RegressionBasedDIDResult{<:DynamicTreatment}, names=nothing;
     ncell = length(rows)
     pcf = view(treatcoef(r), inds)
     cweights = zeros(length(pcf), ncell)
-    pcellweights = view(r.cellweights, inds)
-    pcellcounts = view(r.cellcounts, inds)
+    ptreatweights = view(r.treatweights, inds)
+    ptreatcounts = view(r.treatcounts, inds)
     # Ensure the weights for each relative time always sum up to one
     rels = view(r.treatcells.rel, inds)
     for (i, rs) in enumerate(rows)
         if length(rs) > 1
             relgroups = _groupfind(view(rels, rs))
-            for inds in values(relgroups)
-                if length(inds) > 1
-                    cwts = view(pcellweights, view(rs, inds))
-                    cweights[view(rs, inds), i] .= cwts ./ sum(cwts)
+            for ids in values(relgroups)
+                if length(ids) > 1
+                    cwts = view(ptreatweights, view(rs, ids))
+                    cweights[view(rs, ids), i] .= cwts ./ sum(cwts)
                 else
-                    cweights[rs[inds[1]], i] = 1.0
+                    cweights[rs[ids[1]], i] = 1.0
                 end
             end
         else
@@ -221,8 +308,8 @@ function agg(r::RegressionBasedDIDResult{<:DynamicTreatment}, names=nothing;
     end
     cf = cweights' * pcf
     v = cweights' * view(treatvcov(r), inds, inds) * cweights
-    cellweights = [sum(pcellweights[rows[i]]) for i in 1:ncell]
-    cellcounts = [sum(pcellcounts[rows[i]]) for i in 1:ncell]
+    treatweights = [sum(ptreatweights[rows[i]]) for i in 1:ncell]
+    treatcounts = [sum(ptreatcounts[rows[i]]) for i in 1:ncell]
     cnames = _treatnames(tcells)
     coefinds = Dict(cnames .=> keys(cnames))
     if r.lsweights === nothing
@@ -232,8 +319,8 @@ function agg(r::RegressionBasedDIDResult{<:DynamicTreatment}, names=nothing;
         lswt = TableIndexedMatrix(lswtmat, r.lsweights.r, tcells)
     end
     return AggregatedRegDIDResult{typeof(r.tr), lswt!==nothing, typeof(r), typeof(inds)}(
-        r, inds, cf, v, cweights, cellweights, cellcounts, cnames, coefinds, tcells,
-        lswt, r.ycellmeans, r.ycellweights, r.ycellcounts)
+        r, inds, cf, v, cweights, treatweights, treatcounts, cnames, coefinds, tcells,
+        lswt, r.cellymeans, r.cellweights, r.cellcounts)
 end
 
 vce(r::AggregatedRegDIDResult) = vce(parent(r))
@@ -272,7 +359,7 @@ The least-square weights are stored in a `Matrix` that can be retrieved
 with property name `:m`,
 where the weights for each treatment coefficient
 are stored columnwise starting from the second column and
-the first column contains the cell-level averages.
+the first column contains the cell-level averages of outcome variable.
 The indices for cells can be accessed with property name `:r`;
 and indices for identifying the coefficients can be accessed with property name `:c`.
 The [`RegDIDResultOrAgg`](@ref)s used to generate the `ContrastResult`
@@ -316,10 +403,10 @@ function contrast(r1::RegDIDResultOrAgg, rs::RegDIDResultOrAgg...)
         ncoef += ntreatcoef(r)
     end
     rs = RegDIDResultOrAgg[r1, rs...]
-    m = hcat(r1.ycellmeans, (r.lsweights.m for r in rs)...)
+    m = hcat(r1.cellymeans, (r.lsweights.m for r in rs)...)
     rinds = vcat(0, (fill(i+1, ntreatcoef(r)) for (i, r) in enumerate(rs))...)
     cinds = vcat(0, (1:ntreatcoef(r) for r in rs)...)
-    names = vcat("cellmeans", (treatnames(r) for r in rs)...)
+    names = vcat("cellymeans", (treatnames(r) for r in rs)...)
     ci = VecColumnTable((iresult=rinds, icoef=cinds, name=names))
     return ContrastResult(rs, TableIndexedMatrix(m, ri, ci))
 end

--- a/src/procedures.jl
+++ b/src/procedures.jl
@@ -568,7 +568,6 @@ function solveleastsquaresweights(::DynamicTreatment{SharpDesign},
         cellcounts=nothing)
     cellnames = propertynames(cells)
     length(lswtnames) == 0 && (lswtnames = cellnames)
-    nlswt = length(lswtnames)
     for n in lswtnames
         n in cellnames || throw(ArgumentError("$n is invalid for lswtnames"))
     end

--- a/src/procedures.jl
+++ b/src/procedures.jl
@@ -342,18 +342,18 @@ function maketreatcols(data, treatname::Symbol, treatintterms::TermSet,
     # Generate treatment indicators
     ntcells = length(treatrows)
     treatcols = Vector{Vector{Float64}}(undef, ntcells)
-    cellweights = Vector{Float64}(undef, ntcells)
-    cellcounts = Vector{Int}(undef, ntcells)
+    treatweights = Vector{Float64}(undef, ntcells)
+    treatcounts = Vector{Int}(undef, ntcells)
     @inbounds for i in 1:ntcells
         rs = treatrows[i]
         tcol = zeros(nobs)
         tcol[rs] .= 1.0
         treatcols[i] = tcol
-        cellcounts[i] = length(rs)
+        treatcounts[i] = length(rs)
         if weights isa UnitWeights
-            cellweights[i] = cellcounts[i]
+            treatweights[i] = treatcounts[i]
         else
-            cellweights[i] = sum(view(weights, rs))
+            treatweights[i] = sum(view(weights, rs))
         end
     end
 
@@ -370,8 +370,8 @@ function maketreatcols(data, treatname::Symbol, treatintterms::TermSet,
 
     return (cells=cells::VecColumnTable, rows=rows::Vector{Vector{Int}},
         treatcells=treatcells::VecColumnTable, treatrows=treatrows::Vector{Vector{Int}},
-        treatcols=treatcols::Vector{Vector{Float64}}, cellweights=cellweights,
-        cellcounts=cellcounts)
+        treatcols=treatcols::Vector{Vector{Float64}}, treatweights=treatweights,
+        treatcounts=treatcounts)
 end
 
 """
@@ -419,6 +419,7 @@ See also [`SolveLeastSquares`](@ref).
 function solveleastsquares!(tr::DynamicTreatment{SharpDesign}, pr::TrendOrUnspecifiedPR,
         yterm::AbstractTerm, xterms::TermSet, yxterms::Dict, yxcols::Dict,
         treatcells::VecColumnTable, treatcols::Vector,
+        treatweights::Vector, treatcounts::Vector,
         cohortinteracted::Bool, has_fe_intercept::Bool)
 
     y = yxcols[yxterms[yterm]]
@@ -433,6 +434,9 @@ function solveleastsquares!(tr::DynamicTreatment{SharpDesign}, pr::TrendOrUnspec
     end
     treatcells = VecColumnTable(treatcells, tinds)
     tcols = view(treatcols, tinds)
+    # Copy the relevant weights and counts
+    tweights = treatweights[tinds]
+    tcounts = treatcounts[tinds]
 
     has_intercept, has_omitsintercept = parse_intercept!(xterms)
     xwidth = 0
@@ -453,6 +457,7 @@ function solveleastsquares!(tr::DynamicTreatment{SharpDesign}, pr::TrendOrUnspec
 
     X = hcat(tcols..., (yxcols[x] for x in xs)...)
     
+    # Check collinearity
     ntcols = length(tcols)
     basiscols = trues(size(X,2))
     if size(X, 2) > ntcols
@@ -471,7 +476,8 @@ function solveleastsquares!(tr::DynamicTreatment{SharpDesign}, pr::TrendOrUnspec
     return (coef=coef::Vector{Float64}, X=X::Matrix{Float64},
         crossx=crossx::Cholesky{Float64,Matrix{Float64}},
         residuals=residuals::Vector{Float64}, treatcells=treatcells::VecColumnTable,
-        xterms=xs::Vector{AbstractTerm}, basiscols=basiscols::BitVector)
+        xterms=xs::Vector{AbstractTerm}, basiscols=basiscols::BitVector,
+        treatweights=tweights::Vector{Float64}, treatcounts=tcounts::Vector{Int})
 end
 
 """
@@ -483,7 +489,8 @@ solve the least squares problem for regression coefficients and residuals.
 const SolveLeastSquares = StatsStep{:SolveLeastSquares, typeof(solveleastsquares!), true}
 
 required(::SolveLeastSquares) = (:tr, :pr, :yterm, :xterms, :yxterms, :yxcols,
-    :treatcells, :treatcols, :cohortinteracted, :has_fe_intercept)
+    :treatcells, :treatcols, :treatweights, :treatcounts,
+    :cohortinteracted, :has_fe_intercept)
 copyargs(::SolveLeastSquares) = (4,)
 
 function _vce(data, esample::BitVector,
@@ -545,6 +552,8 @@ required(::EstVcov) = (:data, :esample, :vce, :coef, :X, :crossx, :residuals, :x
     solveleastsquaresweights(args...)
 
 Solve the cell-level weights assigned by least squares.
+If `lswtnames` is not specified,
+cells are defined by the partition based on treatment time and calendar time.
 See also [`SolveLeastSquaresWeights`](@ref).
 """
 function solveleastsquaresweights(::DynamicTreatment{SharpDesign},
@@ -555,8 +564,8 @@ function solveleastsquaresweights(::DynamicTreatment{SharpDesign},
         feM::Union{AbstractFixedEffectSolver, Nothing}, fetol::Real, femaxiter::Int,
         weights::AbstractWeights)
 
-    solvelsweights || return (lsweights=nothing, ycellmeans=nothing, ycellweights=nothing,
-        ycellcounts=nothing)
+    solvelsweights || return (lsweights=nothing, cellymeans=nothing, cellweights=nothing,
+        cellcounts=nothing)
     cellnames = propertynames(cells)
     length(lswtnames) == 0 && (lswtnames = cellnames)
     nlswt = length(lswtnames)
@@ -588,9 +597,9 @@ function solveleastsquaresweights(::DynamicTreatment{SharpDesign},
     d = Matrix{Float64}(undef, length(yresid), 1)
     nlswtrow = length(lswtrows)
     lswtmat = Matrix{Float64}(undef, nlswtrow, nt)
-    ycellmeans = zeros(nlswtrow)
-    ycellweights = zeros(nlswtrow)
-    ycellcounts = zeros(Int, nlswtrow)
+    cellymeans = zeros(nlswtrow)
+    cellweights = zeros(nlswtrow)
+    cellcounts = zeros(Int, nlswtrow)
     @inbounds for i in 1:nlswtrow
         # Reinitialize d for reuse
         fill!(d, 0.0)
@@ -598,18 +607,18 @@ function solveleastsquaresweights(::DynamicTreatment{SharpDesign},
             rs = rows[r]
             d[rs] .= 1.0
             wts = view(weights, rs)
-            ycellmeans[i] += sum(view(yresid, rs).*wts)
-            ycellweights[i] += sum(wts)
-            ycellcounts[i] += length(rs)
+            cellymeans[i] += sum(view(yresid, rs).*wts)
+            cellweights[i] += sum(wts)
+            cellcounts[i] += length(rs)
         end
         feM === nothing || _feresiduals!(d, feM, fetol, femaxiter)
         weights isa UnitWeights || (d .*= sqrt.(weights))
         lswtmat[i,:] .= view((crossx \ (X'd)), 1:nt)
     end
-    ycellmeans ./= ycellweights
+    cellymeans ./= cellweights
     lswt = TableIndexedMatrix(lswtmat, lswtcells, treatcells)
-    return (lsweights=lswt, ycellmeans=ycellmeans, ycellweights=ycellweights,
-        ycellcounts=ycellcounts)
+    return (lsweights=lswt, cellymeans=cellymeans, cellweights=cellweights,
+        cellcounts=cellcounts)
 end
 
 """
@@ -617,6 +626,8 @@ end
 
 Call [`InteractionWeightedDIDs.solveleastsquaresweights`](@ref)
 to solve the cell-level weights assigned by least squares.
+If `lswtnames` is not specified,
+cells are defined by the partition based on treatment time and calendar time.
 """
 const SolveLeastSquaresWeights = StatsStep{:SolveLeastSquaresWeights,
     typeof(solveleastsquaresweights), true}

--- a/test/procedures.jl
+++ b/test/procedures.jl
@@ -225,7 +225,7 @@ end
     @test length(ret.rows) == 20
     @test size(ret.treatcells) == (12, 2)
     @test length(ret.treatcols) == length(ret.treatrows) == 12
-    @test length(ret.cellweights) == length(ret.cellcounts) == length(ret.treatrows)
+    @test length(ret.treatweights) == length(ret.treatcounts) == length(ret.treatrows)
     @test ret.cells.wave_hosp == repeat(8:11, inner=5)
     @test ret.cells.wave == repeat(7:11, 4)
     @test ret.rows[end] == findall((hrs.wave_hosp.==11).&(hrs.wave.==11))
@@ -235,8 +235,8 @@ end
     @test ret.treatrows[1] == findall((hrs.wave_hosp.==8).&(hrs.wave.==8))
     col = convert(Vector{Float64}, (hrs.wave_hosp.==8).&(hrs.wave.==8))
     @test ret.treatcols[1] == col
-    @test ret.cellweights == ret.cellcounts
-    w = ret.cellweights
+    @test ret.treatweights == ret.treatcounts
+    w = ret.treatweights
     @test all(w[ret.treatcells.wave_hosp.==8].==252)
     @test all(w[ret.treatcells.wave_hosp.==9].==176)
     @test all(w[ret.treatcells.wave_hosp.==10].==163)
@@ -247,7 +247,7 @@ end
     @test length(ret1.rows) == 40
     @test size(ret1.treatcells) == (24, 3)
     @test length(ret1.treatcols) == length(ret1.treatrows) == 24
-    @test length(ret1.cellweights) == length(ret1.cellcounts) == length(ret1.treatrows)
+    @test length(ret1.treatweights) == length(ret1.treatcounts) == length(ret1.treatrows)
     @test ret1.cells.wave_hosp == repeat(8:11, inner=10)
     @test ret1.cells.wave == repeat(repeat(7:11, inner=2), 4)
     @test ret1.cells.male == repeat(0:1, 20)
@@ -258,7 +258,7 @@ end
     @test ret1.treatrows[1] == findall((hrs.wave_hosp.==8).&(hrs.wave.==8).&(hrs.male.==0))
     col1 = convert(Vector{Float64}, (hrs.wave_hosp.==8).&(hrs.wave.==8).&(hrs.male.==0))
     @test ret1.treatcols[1] == col1
-    @test ret1.cellweights == ret1.cellcounts
+    @test ret1.treatweights == ret1.treatcounts
 
     nt = merge(nt, (cohortinteracted=false, treatintterms=TermSet()))
     ret2 = maketreatcols(nt..., tr.time, Dict(-1=>1), IdDict{ValidTimeType,Int}(11=>1))
@@ -267,12 +267,12 @@ end
     @test ret2.rows == ret.rows
     @test size(ret2.treatcells) == (6, 1)
     @test length(ret2.treatcols) == length(ret2.treatrows) == 6
-    @test length(ret2.cellweights) == length(ret2.cellcounts) == length(ret2.treatrows)
+    @test length(ret2.treatweights) == length(ret2.treatcounts) == length(ret2.treatrows)
     @test ret2.treatcells.rel == [-3, -2, 0, 1, 2, 3]
     @test ret2.treatrows[1] == findall((hrs.wave.-hrs.wave_hosp.==-3).&(hrs.wave_hosp.!=11))
     col2 = convert(Vector{Float64}, (hrs.wave.-hrs.wave_hosp.==-3).&(hrs.wave_hosp.!=11))
     @test ret2.treatcols[1] == col2
-    @test ret2.cellweights == ret2.cellcounts
+    @test ret2.treatweights == ret2.treatcounts
 
     nt = merge(nt, (treatintterms=TermSet(term(:male)),))
     ret3 = maketreatcols(nt..., tr.time, Dict(-1=>1), IdDict{ValidTimeType,Int}(11=>1))
@@ -282,7 +282,7 @@ end
     @test ret3.rows == ret1.rows
     @test size(ret3.treatcells) == (12, 2)
     @test length(ret3.treatcols) == length(ret3.treatrows) == 12
-    @test length(ret3.cellweights) == length(ret3.cellcounts) == length(ret3.treatrows)
+    @test length(ret3.treatweights) == length(ret3.treatcounts) == length(ret3.treatrows)
     @test ret3.treatcells.rel == repeat([-3, -2, 0, 1, 2, 3], inner=2)
     @test ret3.treatcells.male == repeat(0:1, 6)
     @test ret3.treatrows[1] ==
@@ -301,8 +301,8 @@ end
     defaults = (default(MakeTreatCols())...,)
     _feresiduals!(col, feM, defaults[2:3]...)
     @test ret.treatcols[1] == (col.*sqrt.(wt))[:]
-    @test ret.cellcounts == [252, 252, 252, 251, 176, 176, 176, 175, 162, 160, 163, 162]
-    @test ret.cellweights[1] == 1776173
+    @test ret.treatcounts == [252, 252, 252, 251, 176, 176, 176, 175, 162, 160, 163, 162]
+    @test ret.treatweights[1] == 1776173
 
     allntargs = NamedTuple[(tr=tr, pr=pr)]
     @test combinedargs(MakeTreatCols(), allntargs) ==
@@ -332,8 +332,8 @@ end
     @test ret1.treatcells[2] == ret.treatcells[2]
     @test ret1.treatrows == ret.treatrows
     @test ret1.treatcols == ret.treatcols
-    @test ret1.cellweights == ret.cellweights
-    @test ret1.cellcounts == ret.cellcounts
+    @test ret1.treatweights == ret.treatweights
+    @test ret1.treatcounts == ret.treatcounts
 
     rot = ifelse.(isodd.(hrs.hhidpn), 1, 2)
     df.wave = RotatingTimeArray(rot, hrs.wave)
@@ -360,13 +360,13 @@ end
     @test ret3.treatcells[2] == ret2.treatcells[2]
     @test ret3.treatrows == ret2.treatrows
     @test ret3.treatcols == ret2.treatcols
-    @test ret3.cellweights == ret2.cellweights
-    @test ret3.cellcounts == ret2.cellcounts
+    @test ret3.treatweights == ret2.treatweights
+    @test ret3.treatcounts == ret2.treatcounts
 
     nt = merge(nt, (data=hrs, tr=tr, pr=pr))
     @test MakeTreatCols()(nt) == merge(nt, (cells=ret.cells, rows=ret.rows,
         treatcells=ret.treatcells, treatrows=ret.treatrows, treatcols=ret.treatcols,
-        cellweights=ret.cellweights, cellcounts=ret.cellcounts))
+        treatweights=ret.treatweights, treatcounts=ret.treatcounts))
 end
 
 @testset "SolveLeastSquares" begin
@@ -384,10 +384,14 @@ end
         yxterms[term(:male)]=>hrs.male, yxterms[term(:spouse)]=>hrs.spouse)
     col0 = convert(Vector{Float64}, (hrs.wave_hosp.==10).&(hrs.wave.==10))
     col1 = convert(Vector{Float64}, (hrs.wave_hosp.==10).&(hrs.wave.==11))
-    treatcells0 = VecColumnTable((rel=[0, 1], wave_hosp=[10, 10]))
-    treatcols0 = [col0, col1]
+    col2 = convert(Vector{Float64}, (hrs.wave_hosp.==11).&(hrs.wave.==11))
+    treatcells0 = VecColumnTable((wave_hosp=[10, 10, 11], rel=[0, 1, 0]))
+    treatcols0 = [col0, col1, col2]
+    treatcounts0 = [sum(c.==1) for c in treatcols0]
+    treatweights0 = convert(Vector{Float64}, treatcounts0)
     nt = (tr=tr, pr=pr, yterm=term(:oop_spend), xterms=TermSet(term(1)), yxterms=yxterms,
         yxcols=yxcols0, treatcells=treatcells0, treatcols=treatcols0,
+        treatweights=treatweights0, treatcounts=treatcounts0,
         cohortinteracted=true, has_fe_intercept=false)
     ret = solveleastsquares!(nt...)
     # Compare estimates with Stata
@@ -424,15 +428,18 @@ end
     @test sum(ret1.basiscols) == 3
 
     treatcells1 = VecColumnTable((rel=[0, 1, 1, 1], wave_hosp=[10, 10, 0, 1]))
-    treatcols1 = push!(copy(treatcols0), ones(N), ones(N))
+    treatcols1 = push!(treatcols0[1:2], ones(N), ones(N))
+    treatweights1 = push!(copy(treatweights0), 10.0)
+    treatcounts1 = push!(copy(treatcounts0), 10)
     # basecol is rather conservative in dropping collinear columns
     # If there are three constant columns, it may be that only one of them gets dropped
     # Also need to have at least one term in xterms for basiscol to work
     yxcols2 = Dict(yxterms[term(:oop_spend)]=>hrs.oop_spend, yxterms[term(:male)]=>hrs.male)
     nt1 = merge(nt1, (xterms=TermSet(term(:male), term(0)), treatcells=treatcells1,
-        yxcols=yxcols2, treatcols=treatcols1))
+        yxcols=yxcols2, treatcols=treatcols1, treatweights=treatweights1,
+        treatcounts=treatcounts1))
     @test_throws ErrorException solveleastsquares!(nt1...)
-    
+
     @test SolveLeastSquares()(nt) == merge(nt, ret)
 end
 
@@ -557,8 +564,8 @@ end
     @test lswt[lswt.r.wave_hosp.==10, 1] ≈ [-1/3, -1/3, -1/3, 1, 0] atol=fetol
     @test lswt[lswt.r.wave_hosp.==10, 2] ≈ [-1/3, -1/3, -1/3, 0, 1] atol=fetol
     @test all(x->isapprox(x, 0, atol=fetol), lswt[lswt.r.wave_hosp.!=10, :])
-    @test ret.ycellweights == ret.ycellcounts == length.(rows)
-    @test all(i->ret.ycellmeans[i] ≈ sum(y[rows[i]])/length(rows[i]), 1:length(rows))
+    @test ret.cellweights == ret.cellcounts == length.(rows)
+    @test all(i->ret.cellymeans[i] ≈ sum(y[rows[i]])/length(rows[i]), 1:length(rows))
 
     nt0 = merge(nt, (lswtnames=(:no,),))
     @test_throws ArgumentError solveleastsquaresweights(nt0...)
@@ -602,7 +609,7 @@ end
     @test lswt[lswt.r.wave.==10, 1] ≈ lswt[lswt.r.wave.==11, 2]
     @test lswt[lswt.r.wave.==11, 1] ≈ lswt[lswt.r.wave.==10, 2]
     y1 = y .- cf[3].*x
-    @test all(i->ret.ycellmeans[i] == sum(y1[rows[i]])/length(rows[i]), 1:length(rows))
+    @test all(i->ret.cellymeans[i] == sum(y1[rows[i]])/length(rows[i]), 1:length(rows))
 
     @test SolveLeastSquaresWeights()(nt) == merge(nt, ret)
 end


### PR DESCRIPTION
Some field names are changed to reduce the chance of getting confused.

Irrelevant elements from `treatweights` (previously `cellweights`) were left in the results and led to wrong answers when aggregating estimates via `agg`. This is now fixed.